### PR TITLE
Added fix for camera causing state loss on orientation change

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         <activity
             android:name=".HiddenActivity"
             android:launchMode="singleTop"
+            android:screenOrientation="behind"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />
 
     </application>


### PR DESCRIPTION
Added fix for camera causing state loss on orientation change. This occurs when the calling activity or fragment doesn't implement state management or restricts orientation changes. HiddenActivity could cause an orientation change resulting in state loss. This fix resolves this by ensuring HiddenActivity always orients itself to whatever activity preceeded it.