### PR TITLE
Removed allowBackup and supportsRtl from library manifest

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -4,9 +4,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
         <activity
             android:name=".HiddenActivity"


### PR DESCRIPTION
It’s up to the implementer of the library whether their app wants to use these properties. They don’t server any purpose for this library, so it’s best to remove them.

Resolved #37