### PR TITLE
Fixed an issue where permissions dialog wasn’t launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ dependencies {
 }
 ```
 
+If you intend to use the camera, add the following to your AndroidManifest:
+
+`<uses-permission android:name="android.permission.CAMERA"/>`
+
 ## Example
 
 ```java

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mlsdev.sample">
 
+    <uses-permission android:name="android.permission.CAMERA"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
The CAMERA permission needs to be declared in the manifest. It’s not wise to put this permission straight into the library’s manifest though, we don’t want to force consumers of the library to inherit this permission, as they may only be using this library for gallery image loading.

So, the CAMERA permission is just declared in the sample app’s manifest.

Secondly, only the required permissions should be checked per image Source. So, if the Source is just gallery, we only request WRITE_EXTERNAL_STORAGE permissions. If the Source is Camera, we request both WRITE_EXTERNAL_STORAGE and CAMERA.

Resolves #49